### PR TITLE
Document follow-up maintenance tasks

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,22 @@
+# Proposed Maintenance Tasks
+
+## Fix a Typographical Error
+* **Issue**: In `MetaboLiteLearner.m`, several property comments contain typographical errors (e.g., "meatbolite" instead of "metabolite", "reponse" instead of "response"). These reduce readability when browsing the class documentation.
+* **Proposed Task**: Correct the spelling errors in the property documentation block of `MetaboLiteLearner`.
+* **Files**: `MetaboLiteLearner.m`
+
+## Resolve a Bug
+* **Issue**: `optimizeComponentsAndLearn` computes the optimal component count with `max(find(...))`. When no component index satisfies the condition (which happens if the minimum-error model also satisfies the one-standard-error rule), the `find` returns empty, propagating an empty `nopt` that later causes indexing failures.
+* **Proposed Task**: Update the logic so that `nopt` defaults to `nMin` when the `find` result is empty, ensuring the method always returns a valid component count.
+* **Files**: `MetaboLiteLearner.m`
+
+## Align Documentation With Code
+* **Issue**: The header comment in `convertAgilentToCvs.m` states the GCMS matrix has 500 m/z columns, but the code (and documented range 50–599) actually yields 550 columns.
+* **Proposed Task**: Correct the documentation block to state that there are 550 m/z columns so the description matches the implementation.
+* **Files**: `convertAgilentToCvs.m`
+
+## Improve Testing
+* **Issue**: The repository lacks automated coverage for `extractSpectraAndIntegrate`. Without a regression test, changes could silently break the peak-integration or spectrum-export logic.
+* **Proposed Task**: Add a MATLAB unit test that runs `extractSpectraAndIntegrate` on a small fixture dataset and verifies the shape and key statistics of the produced tables.
+* **Files**: New MATLAB test file (e.g., `tests/TestExtractSpectraAndIntegrate.m`)
+


### PR DESCRIPTION
## Summary
- add TASKS.md describing high-impact follow-up maintenance items covering typos, a bug, documentation, and testing gaps

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e516dcc5e88326afd4fc4cadbdb3d2