### PR TITLE
Port MetaboLiteLearner workflow from MATLAB to Python with CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,104 +1,90 @@
-# MetaboLiteLearner: a lightweight machine learning algorithm to learn metabolic rewiring from GC/MS data
+# MetaboLiteLearner: Python port of the metabolic rewiring GC/MS workflow
 
-This repository contains a MATLAB script `scMeboLiteLearnerWorkFlow.m` which implements the entire MetaboLiteLearner workflow. Below is a detailed description of the script.
+This repository now includes a Python implementation of the original MATLAB-based MetaboLiteLearner workflow. The Python code mirrors the same top-level stages:
 
-## How to use the script
+1. convert Agilent sample directories into the repository's matrix CSV format,
+2. extract TIC peaks and bulk spectra,
+3. remove peaks that are not significantly different from media,
+4. fit mixed-effects models to estimate corrected fold changes,
+5. learn latent components with partial least squares regression, and
+6. generate the same workflow summary artifacts in the `folds/` directory.
 
-This script can be executed in a MATLAB environment. The script outlines the steps to preprocess the data, compute the fold change for each metabolite, and plot the percentage of variance explained by each component. The default settings are set to skip workflow steps, but this can be changed by setting variables to true. For example, if you set `**DOWNLOAD = true;**`, the script will download the raw data from Zenodo.
+The original MATLAB files are still present as reference implementations, but the supported workflow entry point is now the Python package in `metabolite_learner/`.
 
-The script is divided into several steps:
+## Python package layout
 
-1. **Download the raw data from Zenodo:** This step downloads the raw Agilent data from the Zenodo repository and saves it in a directory named 'rawAgilentData'.
-2. **Convert Agilent files to CSV:** This step imports the Agilent data, bins it, and exports it as CSV files. It requires `chromatography-master` in the path.
-3. **Extract Spectra and Integrate:** This step extracts the spectra and integrates it, generating two tables: `tblPeaksIntegrated` and `tblSpectra`.
-4. **Load peak data:** This step loads the previously generated tables and extracts the sample type from the sample name.
-5. **Remove peaks that are not different from media:** This step performs ANOVA tests to remove peaks that are not significantly different from media.
-6. **Rescale samples:** This step rescales the samples using the intracellular metabolome.
-7. **Fit model and calculate corrected peak areas:** This step uses linear mixed effects models to calculate corrected peak areas.
-8. **Compute the fold change for each metabolite in B and L:** This step computes the fold change for each metabolite in B and L and saves the folds table.
-9. **Remove spectra that are not in foldchange table (compounds unchanged):** This step removes spectra that are not present in the fold change table.
-10. **Determine number of latent components (metaboLiteLearner.m):** This step determines the number of latent components using the MetaboLiteLearner.
-11. **Plot the percentage of variance explained by each component for X and Y:** This step generates a bar plot to visualize the percentage of variance explained by each component for X and Y.
-12. **Plot the loadings of the latent component:** This step plots the loadings of the latent component.
+- `metabolite_learner/agilent.py`: Agilent conversion step with an injectable raw-data loader.
+- `metabolite_learner/extract.py`: TIC peak detection, peak integration, and spectrum export.
+- `metabolite_learner/workflow.py`: end-to-end analysis pipeline, including ANOVA, mixed models, and plotting.
+- `metabolite_learner/pls.py`: `MetaboLiteLearner` partial least squares implementation.
+- `metabolite_learner/cli.py`: command-line interface.
 
-## Required Dependencies
+## Installation
 
-To use this script, the following dependencies are required:
-- MATLAB Statistics and Marchine Learning toolbox
-- [Chromatography-Master](https://www.mathworks.com/matlabcentral/fileexchange/47696-chromatography-toolbox) (for the conversion of Agilent data to CSV).
+The Python port targets Python 3.10+ and depends on:
+
+- `numpy`
+- `pandas`
+- `scipy`
+- `scikit-learn`
+- `statsmodels`
+- `matplotlib`
+
+Install the project in editable mode:
+
+```bash
+python3 -m pip install -e .
+```
+
+## Usage
+
+### 1. Extract peaks and spectra from the existing GC/MS matrix CSV files
+
+```bash
+python3 -m metabolite_learner extract-peaks gcmsCSVs extractedPeaks
+```
+
+This writes:
+
+- `extractedPeaks/tblTicPeaks.csv`
+- `extractedPeaks/tblPeaksIntegrated.csv`
+- `extractedPeaks/tblSpectra.csv`
+
+### 2. Run the full workflow
+
+```bash
+python3 -m metabolite_learner run-workflow \
+  --gcms-csv-dir gcmsCSVs \
+  --extracted-peaks-dir extractedPeaks \
+  --folds-dir folds
+```
+
+This produces:
+
+- `folds/peakFoldChanges.csv`
+- `folds/variance_explained.png`
+- `folds/loadings.png`
+
+### 3. Agilent raw-data conversion
+
+```bash
+python3 -m metabolite_learner convert-agilent rawAgilentData/... gcmsCSVs
+```
+
+Unlike the MATLAB version, the Python implementation does not hard-code a dependency on `chromatography-master`. Instead, `convert_agilent_to_csv` accepts a pluggable loader because Agilent `.D` directories are proprietary vendor containers. Out of the box, the function looks for a pre-exported matrix CSV inside each `.D` directory.
+
+## Notes on parity with MATLAB
+
+- The statistical workflow follows the same sequence as `scMeboLiteLearnerWorkFlow.m`.
+- `statsmodels` is used for the OLS ANOVA and mixed-effects models.
+- `scikit-learn` is used for the PLS learner and cross-validation.
+- The Python peak extractor uses `scipy.signal.find_peaks` and half-height peak widths as a replacement for MATLAB's `mspeaks`.
+- KEGG plotting remains best-effort because the `.mat` file contains a MATLAB table structure whose representation can vary by SciPy version.
 
 ## Data
 
-The data used in this script is sourced from the Zenodo repository. For detailed insights on the data, please refer to: [Zenodo Repository](https://zenodo.org/record/8193580/)
-
-## Output
-
-This script's output includes various graphs and CSV files related to the MetaboLiteLearner workflow, including the percentage of variance explained by each component and the fold changes of each metabolite in B and L. For examples of these outputs, refer to [add ink to bioRXiv].
-
-## Functions
-
-### convertAgilentToCsv(dataDir, outputDir)
-
-Converts Agilent .D files into CSV text files. The GCMS data is represented as a 2,401 x 550 matrix, with 2,401 rows representing the time steps from 6 to 30 minutes (in 0.01-minute intervals) and 550 columns representing the m/z steps from 50 to 599 (in unit intervals). The function requires `chromatography-master` in the path.
-* `dataDir`: Path to the directory containing .D files.
-* `outputDir`: Path to the directory to save the CSV files.
-
-### extractSpectraAndIntegrate(csvDataDir, outputSpectraDir)
-
-Analyzes GCMS data in the provided directory containing CSV files. It identifies the total ion chromatogram (TIC) peaks, extracts their spectra, and integrates them to create a peak area table. The output tables, tblPeaksIntegrated and tblSpectra, are saved as CSV files in the specified outputSpectraDir directory.
-- `csvDataDir`: The directory containing the GCMS data in CSV format. Each CSV file should represent a sample.
-- `outputSpectraDir`: The directory where the output files, `tblPeaksIntegrated.csv` and `tblSpectra.csv`, will be saved.
-
-## Classes
-
-### MetaboLiteLearner
-
-The `MetaboLiteLearner` class employs [partial least square regression (PLSR)](https://www.mathworks.com/help/stats/plsregress.html) to study associations between the spectrum of a metabolite and a corresponding response variable.
-
-##### Properties
-
-###### Input Properties
-- **xFullData**: Spectra for each metabolite.
-- **yFullData**: Response variable.
-- **kfold**: k-fold used for estimating loss and optimizing components.
-- **maxn**: Maximum number of components tested.
-- **nrandomized**: Number of shuffling iterations for testing.
-
-###### State Variables
-- **cvIndices**: Cross-validation indices.
-- **nopt**: Optimum number of components.
-- **testSse**: Sum of squared errors of held-out examples for evaluation.
-- **BETA**: Coefficients of the linear model trained with all data.
-- **PCTVAR**: Percent variance explained.
-- **Ypred**: Fit results.
-- **XL**: Loadings of the X.
-- **YL**: Loadings of the Y.
-- **XS**: Scores of input data mapped onto `nopt`-dimensional latent space.
-- **YS**: Scores of output data mapped onto `nopt`-dimensional latent space.
-- **stats**: Output of the `plsregress`.
-
-##### Methods
-
-###### Constructor
-- `MetaboLiteLearner(x, y, kfold, maxn, nrandomized)`: Constructs an instance of the class.
-
-###### Public Methods
-- `mapToLatentSpace(x)`: Maps a set of spectra to the latent space.
-- `shufflingTest()`: Performs a shuffling test.
-- `learn(x, y, n)`: Executes PLSR with `n` components.
-- `crossValidationEvaluation(x, y, n)`: Evaluates a PLSR model with 'n' components using k-fold cross-validation.
-- `optimizeComponentsAndLearn()`: Determines the number of components that minimizes the evaluation loss.
+The repository still contains the processed GC/MS matrix CSVs in `gcmsCSVs/`, the extracted peak tables in `extractedPeaks/`, and the reference fold-change table in `folds/`.
 
 ## License
 
-Example 1: MIT License
-License
-This project is licensed under the MIT License. This allows anyone to freely use, modify, and distribute the software, even in proprietary projects, provided that the original copyright notice and disclaimer of warranty are included in all copies or substantial portions of the software. For the full license text, see the LICENSE file.
-
-## Contributing
-
-If you'd like to contribute to this project, please get in touch with xavierj@mskcc.org.
-
-## Issues and Support
-
-For any issues, bugs, or feature requests, please open a new issue in the repository. For additional support or questions, please contact xavierj@mskcc.org.
+This project is licensed under the MIT License. See `LICENSE` for details.

--- a/metabolite_learner/__init__.py
+++ b/metabolite_learner/__init__.py
@@ -1,0 +1,5 @@
+"""Python port of the MetaboLiteLearner repository."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/metabolite_learner/__main__.py
+++ b/metabolite_learner/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/metabolite_learner/agilent.py
+++ b/metabolite_learner/agilent.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Iterable
+
+import numpy as np
+import pandas as pd
+
+TIME_GRID = np.round(np.arange(6.0, 30.0 + 0.01, 0.01), 2)
+MZ_GRID = np.arange(50, 600, 1)
+EXPECTED_SHAPE = (TIME_GRID.size, MZ_GRID.size)
+
+Loader = Callable[[Path], np.ndarray]
+
+
+def _identity_matrix_loader(sample_path: Path) -> np.ndarray:
+    candidates = [
+        sample_path / "matrix.csv",
+        sample_path / "xic.csv",
+        sample_path / f"{sample_path.stem}.csv",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            data = pd.read_csv(candidate, header=None).to_numpy(dtype=float)
+            return data
+    raise FileNotFoundError(
+        "No matrix CSV was found inside the Agilent sample directory. "
+        "The Python port expects a pluggable loader that can decode the proprietary "
+        ".D directory into the 2401x550 GC/MS matrix used elsewhere in the repo."
+    )
+
+
+def convert_agilent_to_csv(
+    data_dir: str | Path,
+    output_dir: str | Path,
+    loader: Loader | None = None,
+    sample_dirs: Iterable[Path] | None = None,
+) -> list[Path]:
+    """Convert Agilent sample directories into the repo's CSV matrix format.
+
+    The original MATLAB implementation relied on `ImportAgilent` from the external
+    chromatography-master toolbox. The Python port exposes the same workflow step but
+    makes the raw-data decoder injectable because Agilent `.D` directories are a
+    proprietary vendor format.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory that contains Agilent `.D` sample directories.
+    output_dir:
+        Destination for the generated CSV matrix files.
+    loader:
+        Callable that receives a sample directory and returns a 2401x550 matrix.
+        When omitted, the function looks for a pre-exported matrix CSV inside each
+        sample directory.
+    sample_dirs:
+        Optional explicit iterable of sample directories to process.
+    """
+
+    input_root = Path(data_dir)
+    output_root = Path(output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    if sample_dirs is None:
+        sample_dirs = sorted(path for path in input_root.iterdir() if path.suffix == ".D")
+    else:
+        sample_dirs = sorted(sample_dirs)
+
+    if not sample_dirs:
+        raise FileNotFoundError(f"No Agilent sample directories (*.D) found in {input_root}.")
+
+    matrix_loader = loader or _identity_matrix_loader
+    written_files: list[Path] = []
+
+    for sample_dir in sample_dirs:
+        matrix = np.asarray(matrix_loader(sample_dir), dtype=float)
+        if matrix.shape != EXPECTED_SHAPE:
+            raise ValueError(
+                f"Expected matrix shape {EXPECTED_SHAPE} for {sample_dir.name}, "
+                f"but received {matrix.shape}."
+            )
+        sample_name = sample_dir.stem
+        destination = output_root / f"{sample_name}.csv"
+        pd.DataFrame(matrix).to_csv(destination, header=False, index=False)
+        written_files.append(destination)
+
+    return written_files

--- a/metabolite_learner/cli.py
+++ b/metabolite_learner/cli.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import argparse
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Python port of the MetaboLiteLearner MATLAB workflow.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    convert_parser = subparsers.add_parser("convert-agilent", help="Convert Agilent sample directories into matrix CSVs.")
+    convert_parser.add_argument("data_dir")
+    convert_parser.add_argument("output_dir")
+
+    extract_parser = subparsers.add_parser("extract-peaks", help="Extract TIC peaks and spectra from matrix CSVs.")
+    extract_parser.add_argument("csv_data_dir")
+    extract_parser.add_argument("output_spectra_dir")
+
+    workflow_parser = subparsers.add_parser("run-workflow", help="Run the full MetaboLiteLearner workflow.")
+    workflow_parser.add_argument("--gcms-csv-dir", default="gcmsCSVs")
+    workflow_parser.add_argument("--extracted-peaks-dir", default="extractedPeaks")
+    workflow_parser.add_argument("--folds-dir", default="folds")
+    workflow_parser.add_argument("--kegg-mat-path", default="kegg/keggCompoundsWithFiehlibSpectrum.mat")
+    workflow_parser.add_argument("--regenerate-peaks", action="store_true")
+    workflow_parser.add_argument("--kfold-learn", type=int, default=0)
+    workflow_parser.add_argument("--max-components", type=int, default=30)
+    workflow_parser.add_argument("--nrandomized", type=int, default=1000)
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "convert-agilent":
+        from .agilent import convert_agilent_to_csv
+
+        written = convert_agilent_to_csv(args.data_dir, args.output_dir)
+        print(f"Wrote {len(written)} matrix CSV files.")
+    elif args.command == "extract-peaks":
+        from .extract import extract_spectra_and_integrate
+
+        peaks, spectra = extract_spectra_and_integrate(args.csv_data_dir, args.output_spectra_dir)
+        print(f"Extracted {len(peaks)} TIC peaks and {len(spectra)} summed spectra.")
+    elif args.command == "run-workflow":
+        from .workflow import run_workflow
+
+        result = run_workflow(
+            gcms_csv_dir=args.gcms_csv_dir,
+            extracted_peaks_dir=args.extracted_peaks_dir,
+            folds_dir=args.folds_dir,
+            kegg_mat_path=args.kegg_mat_path,
+            regenerate_peaks=args.regenerate_peaks,
+            kfold_learn=args.kfold_learn,
+            max_components=args.max_components,
+            nrandomized=args.nrandomized,
+        )
+        print(
+            "Completed workflow with "
+            f"{len(result.fold_changes)} fold-change peaks and "
+            f"{result.learner.nopt} latent components."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/metabolite_learner/extract.py
+++ b/metabolite_learner/extract.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy.signal import find_peaks, peak_widths
+
+TIME_GRID = np.round(np.arange(6.0, 30.0 + 0.01, 0.01), 2)
+MZ_GRID = np.arange(50, 600, 1)
+EXPECTED_SHAPE = (TIME_GRID.size, MZ_GRID.size)
+
+
+def _load_matrix_csv(path: Path) -> np.ndarray:
+    matrix = pd.read_csv(path, header=None).to_numpy(dtype=float)
+    if matrix.shape != EXPECTED_SHAPE:
+        raise ValueError(f"{path} has shape {matrix.shape}, expected {EXPECTED_SHAPE}.")
+    return matrix
+
+
+def extract_spectra_and_integrate(
+    csv_data_dir: str | Path,
+    output_spectra_dir: str | Path,
+    *,
+    prominence: float | None = None,
+    distance: int = 3,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Extract bulk TIC peaks and integrated spectra from matrix CSVs."""
+
+    csv_root = Path(csv_data_dir)
+    output_root = Path(output_spectra_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    csv_files = sorted(csv_root.glob("*.csv"))
+    if not csv_files:
+        raise FileNotFoundError(f"No CSV files were found in {csv_root}.")
+
+    sample_names = [path.stem for path in csv_files]
+    sample_matrices = {path.stem: _load_matrix_csv(path) for path in csv_files}
+
+    sample_tic = pd.DataFrame({"time": TIME_GRID})
+    for sample_name, matrix in sample_matrices.items():
+        sample_tic[sample_name] = matrix.sum(axis=1)
+
+    bulk_tic = sample_tic[sample_names].sum(axis=1).to_numpy(dtype=float)
+    effective_prominence = prominence if prominence is not None else np.quantile(bulk_tic, 0.90) * 0.02
+    peaks, properties = find_peaks(bulk_tic, prominence=effective_prominence, distance=distance)
+    if peaks.size == 0:
+        raise RuntimeError("No TIC peaks were detected. Consider reducing the prominence threshold.")
+
+    widths, _, left_ips, right_ips = peak_widths(bulk_tic, peaks, rel_height=0.5)
+    left_idx = np.clip(np.floor(left_ips).astype(int), 0, len(TIME_GRID) - 1)
+    right_idx = np.clip(np.ceil(right_ips).astype(int), 0, len(TIME_GRID) - 1)
+
+    peak_rows: list[dict[str, float]] = []
+    integrated_rows: list[dict[str, float]] = []
+    spectra_rows: list[dict[str, float]] = []
+
+    for peak_index, peak_pos in enumerate(peaks):
+        peak_id = float(TIME_GRID[peak_pos])
+        rt_start = float(TIME_GRID[left_idx[peak_index]])
+        rt_end = float(TIME_GRID[right_idx[peak_index]])
+        peak_rows.append(
+            {
+                "peakId": peak_id,
+                "rtPeak": peak_id,
+                "intensity": float(bulk_tic[peak_pos]),
+                "rtStart": rt_start,
+                "rtEnd": rt_end,
+                "halfHeightWidth": float(widths[peak_index] * 0.01),
+            }
+        )
+
+        integrated_row: dict[str, float] = {"peakId": peak_id}
+        combined_spectrum = np.zeros(MZ_GRID.size, dtype=float)
+        window = slice(left_idx[peak_index], right_idx[peak_index] + 1)
+        for sample_name, matrix in sample_matrices.items():
+            peak_area = matrix[window, :].sum()
+            integrated_row[sample_name] = float(peak_area)
+            combined_spectrum += matrix[window, :].sum(axis=0)
+        integrated_rows.append(integrated_row)
+
+        spectra_row = {"peakId": peak_id}
+        spectra_row.update({f"mz{mz}": float(value) for mz, value in zip(MZ_GRID, combined_spectrum, strict=True)})
+        spectra_rows.append(spectra_row)
+
+    peak_table = pd.DataFrame(peak_rows).sort_values("peakId").reset_index(drop=True)
+    peaks_integrated = pd.DataFrame(integrated_rows).sort_values("peakId").reset_index(drop=True)
+    spectra = pd.DataFrame(spectra_rows).sort_values("peakId").reset_index(drop=True)
+
+    peak_table.to_csv(output_root / "tblTicPeaks.csv", index=False)
+    peaks_integrated.to_csv(output_root / "tblPeaksIntegrated.csv", index=False)
+    spectra.to_csv(output_root / "tblSpectra.csv", index=False)
+
+    return peaks_integrated, spectra

--- a/metabolite_learner/pls.py
+++ b/metabolite_learner/pls.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.model_selection import KFold, LeaveOneOut
+
+
+@dataclass(slots=True)
+class ShufflingTestResult:
+    randomized_mse: np.ndarray
+    real_mse: float
+
+
+class MetaboLiteLearner:
+    """Partial least squares learner mirroring the MATLAB class."""
+
+    def __init__(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        kfold: int = 0,
+        max_components: int = 30,
+        nrandomized: int = 1000,
+        random_state: int = 0,
+    ) -> None:
+        self.x_full_data = np.asarray(x, dtype=float)
+        self.y_full_data = np.asarray(y, dtype=float)
+        self.maxn = min(max_components, self.x_full_data.shape[0] - 1, self.x_full_data.shape[1])
+        self.nrandomized = nrandomized
+        self.random_state = random_state
+        self.cv = LeaveOneOut() if kfold == 0 else KFold(n_splits=kfold, shuffle=True, random_state=random_state)
+        self.kfold = self.x_full_data.shape[0] if kfold == 0 else kfold
+
+        self.nopt, self.test_sse, self.train_sse = self.optimize_components_and_learn()
+        (
+            self.model,
+            self.beta,
+            self.y_pred,
+            self.loss,
+            self.sse,
+            self.x_loadings,
+            self.y_loadings,
+            self.x_scores,
+            self.y_scores,
+            self.pctvar,
+        ) = self.learn(self.x_full_data, self.y_full_data, self.nopt)
+
+    def map_to_latent_space(self, x: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        x = np.asarray(x, dtype=float)
+        latent_scores = self.model.transform(x)
+        predicted_y = self.model.predict(x)
+        return latent_scores, predicted_y
+
+    def shuffling_test(self) -> ShufflingTestResult:
+        rng = np.random.default_rng(self.random_state)
+        randomized = np.zeros(self.nrandomized, dtype=float)
+        for idx in range(self.nrandomized):
+            y_rand = self.y_full_data[rng.permutation(self.y_full_data.shape[0]), :]
+            _, _, kfold_sse, _ = self.cross_validation_evaluation(self.x_full_data, y_rand, self.nopt)
+            randomized[idx] = np.mean(kfold_sse)
+        return ShufflingTestResult(randomized_mse=randomized, real_mse=float(np.mean(self.test_sse[:, self.nopt - 1])))
+
+    def learn(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        n_components: int,
+    ) -> tuple[PLSRegression, np.ndarray, np.ndarray, np.ndarray, float, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        model = PLSRegression(n_components=n_components, scale=False)
+        model.fit(x, y)
+        y_pred = model.predict(x)
+        loss = (y_pred - y) ** 2
+        sse = float(loss.sum())
+
+        beta = np.vstack([model.intercept_.reshape(1, -1), model.coef_])
+        pctvar = self._calculate_pctvar(x, y, model)
+        return (
+            model,
+            beta,
+            y_pred,
+            loss,
+            sse,
+            model.x_loadings_,
+            model.y_loadings_,
+            model.x_scores_,
+            model.y_scores_,
+            pctvar,
+        )
+
+    def cross_validation_evaluation(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        n_components: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        y_pred = np.zeros_like(y, dtype=float)
+        train_sse = np.zeros(self.kfold, dtype=float)
+        kfold_sse = np.zeros(self.kfold, dtype=float)
+        beta_distribution = np.zeros((x.shape[1] + 1, y.shape[1], x.shape[0]), dtype=float)
+
+        for fold_index, (train_idx, test_idx) in enumerate(self.cv.split(x, y)):
+            model, beta, _, _, sse, *_ = self.learn(x[train_idx], y[train_idx], n_components)
+            predicted = model.predict(x[test_idx])
+            y_pred[test_idx] = predicted
+            train_sse[fold_index] = sse / train_idx.size
+            kfold_sse[fold_index] = np.sum((predicted - y[test_idx]) ** 2) / test_idx.size
+            for row_idx in test_idx:
+                beta_distribution[:, :, row_idx] = beta
+
+        return y_pred, train_sse, kfold_sse, beta_distribution
+
+    def optimize_components_and_learn(self) -> tuple[int, np.ndarray, np.ndarray]:
+        train_sse = np.zeros((self.kfold, self.maxn), dtype=float)
+        test_sse = np.zeros((self.kfold, self.maxn), dtype=float)
+
+        for component_index in range(1, self.maxn + 1):
+            _, train_sse_component, test_sse_component, _ = self.cross_validation_evaluation(
+                self.x_full_data,
+                self.y_full_data,
+                component_index,
+            )
+            train_sse[:, component_index - 1] = train_sse_component
+            test_sse[:, component_index - 1] = test_sse_component
+
+        mean_test_sse = test_sse.mean(axis=0)
+        n_min = int(np.argmin(mean_test_sse)) + 1
+        std_error = test_sse.std(axis=0, ddof=0) / np.sqrt(test_sse.shape[0])
+        min_error = mean_test_sse[n_min - 1] + std_error[n_min - 1]
+        candidate_idx = np.where((mean_test_sse > min_error) & (np.arange(1, self.maxn + 1) < n_min))[0]
+        n_opt = int(candidate_idx.max() + 1) if candidate_idx.size else n_min
+        return n_opt, test_sse, train_sse
+
+    @staticmethod
+    def _calculate_pctvar(x: np.ndarray, y: np.ndarray, model: PLSRegression) -> np.ndarray:
+        total_x = np.sum((x - x.mean(axis=0, keepdims=True)) ** 2)
+        total_y = np.sum((y - y.mean(axis=0, keepdims=True)) ** 2)
+
+        x_scores = model.x_scores_
+        x_loadings = model.x_loadings_
+        y_scores = model.y_scores_
+        y_loadings = model.y_loadings_
+
+        explained_x = []
+        explained_y = []
+        for component_index in range(model.n_components):
+            x_hat = np.outer(x_scores[:, component_index], x_loadings[:, component_index])
+            y_hat = np.outer(y_scores[:, component_index], y_loadings[:, component_index])
+            explained_x.append(np.sum(x_hat**2) / total_x if total_x else 0.0)
+            explained_y.append(np.sum(y_hat**2) / total_y if total_y else 0.0)
+        return np.vstack([explained_x, explained_y])

--- a/metabolite_learner/workflow.py
+++ b/metabolite_learner/workflow.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import statsmodels.api as sm
+import statsmodels.formula.api as smf
+from scipy.io import loadmat
+from statsmodels.stats.anova import anova_lm
+
+from .extract import extract_spectra_and_integrate
+from .pls import MetaboLiteLearner
+
+
+@dataclass(slots=True)
+class WorkflowResult:
+    fold_changes: pd.DataFrame
+    spectra: pd.DataFrame
+    learner: MetaboLiteLearner
+
+
+def _infer_cell_type(sample_name: str) -> str:
+    return sample_name[0]
+
+
+def _ols_anova_p_value(values: np.ndarray, cell_types: list[str]) -> float:
+    frame = pd.DataFrame({"value": np.log(values), "cell": pd.Categorical(cell_types)})
+    model = smf.ols("value ~ C(cell)", data=frame).fit()
+    return float(anova_lm(model).iloc[0]["PR(>F)"])
+
+
+def _prepare_scaled_table(peaks_integrated: pd.DataFrame) -> pd.DataFrame:
+    melted = peaks_integrated.melt(id_vars="peakId", var_name="sample", value_name="area")
+    melted["sample"] = melted["sample"].astype(str)
+    melted["batch"] = pd.Categorical(
+        np.select(
+            [melted["sample"].str.contains("plate1"), melted["sample"].str.contains("plate2")],
+            ["1", "2"],
+            default="3",
+        )
+    )
+    melted["cell"] = pd.Categorical(melted["sample"].map(_infer_cell_type), categories=["P", "B", "L"])
+    melted["peakId"] = melted["peakId"].astype(str)
+    melted["peak_batch"] = melted["peakId"] + ":" + melted["batch"].astype(str)
+    melted["area"] = np.log(melted["area"].astype(float))
+    return melted
+
+
+def _fit_scaling_model(frame: pd.DataFrame):
+    return smf.mixedlm(
+        "area ~ 0 + C(peakId)",
+        frame,
+        groups=frame["sample"],
+        vc_formula={"peak_batch": "0 + C(peak_batch)"},
+    ).fit(reml=False, method="lbfgs", disp=False)
+
+
+def _fit_fold_change_model(frame: pd.DataFrame):
+    return smf.mixedlm(
+        "area ~ 0 + C(peakId) + C(peakId):C(cell)",
+        frame,
+        groups=frame["sample"],
+        vc_formula={"peak_batch": "0 + C(peak_batch)"},
+    ).fit(reml=False, method="lbfgs", disp=False)
+
+
+def _coefficient_frame(model) -> pd.DataFrame:
+    conf = model.conf_int()
+    params = model.params
+    pvalues = model.pvalues
+    records = []
+    for name, estimate in params.items():
+        if not name.startswith("C(peakId)") or ":C(cell)" not in name:
+            continue
+        peak_part, cell_part = name.split(":")
+        peak_id = peak_part.split("[")[-1].rstrip("]")
+        cell = cell_part.split("[")[-1].rstrip("]").replace("T.", "")
+        records.append(
+            {
+                "peakID": peak_id,
+                "cell": cell,
+                "Estimate": float(estimate),
+                "pValue": float(pvalues[name]),
+                "Lower": float(conf.loc[name, 0]),
+                "Upper": float(conf.loc[name, 1]),
+            }
+        )
+    return pd.DataFrame.from_records(records)
+
+
+def _plot_variance_explained(learner: MetaboLiteLearner, output_dir: Path) -> Path:
+    figure, axes = plt.subplots(2, 1, figsize=(4, 5), constrained_layout=True)
+    axes[0].bar(range(1, learner.nopt + 1), learner.pctvar[0] * 100)
+    axes[0].set_xlabel("Latent component")
+    axes[0].set_ylabel("Explained variance\nin X (%)")
+    axes[0].grid(True)
+    axes[1].bar(range(1, learner.nopt + 1), learner.pctvar[1] * 100)
+    axes[1].set_xlabel("Latent component")
+    axes[1].set_ylabel("Explained variance\nin Y (%)")
+    axes[1].grid(True)
+    path = output_dir / "variance_explained.png"
+    figure.savefig(path, dpi=200)
+    plt.close(figure)
+    return path
+
+
+def _safe_extract_kegg_table(mat_path: Path) -> pd.DataFrame | None:
+    if not mat_path.exists():
+        return None
+    payload = loadmat(mat_path, squeeze_me=True, struct_as_record=False)
+    table = payload.get("tblKegg3")
+    if table is None:
+        return None
+    try:
+        records = []
+        iterable = table if np.ndim(table) else [table]
+        for row in iterable:
+            met_class = getattr(row, "metClassLevel1", None)
+            abundance = getattr(row, "abundance", None)
+            if met_class is None or abundance is None:
+                continue
+            records.append({"metClassLevel1": str(met_class), "abundance": np.asarray(abundance, dtype=float)})
+        return pd.DataFrame.from_records(records)
+    except Exception:
+        return None
+
+
+def _plot_loadings(learner: MetaboLiteLearner, output_dir: Path, kegg_mat: Path) -> Path:
+    figure, axes = plt.subplots(1, 2, figsize=(10, 5), constrained_layout=True)
+    axes[0].plot(learner.beta[:, 0], learner.beta[:, 1] if learner.beta.shape[1] > 1 else learner.beta[:, 0], "k.-")
+    axes[0].axhline(0, color="black", linestyle="--", linewidth=1)
+    axes[0].axvline(0, color="black", linestyle="--", linewidth=1)
+    axes[0].set_xlabel("Brain-homing coefficient")
+    axes[0].set_ylabel("Lung-homing coefficient")
+    axes[0].grid(True)
+
+    if learner.y_loadings.shape[1] >= 2:
+        axes[1].scatter(learner.y_loadings[0], learner.y_loadings[1], c=np.arange(learner.nopt), cmap="viridis")
+    else:
+        axes[1].scatter(np.arange(learner.nopt), learner.y_loadings[0], c=np.arange(learner.nopt), cmap="viridis")
+    axes[1].axhline(0, color="black", linestyle="--", linewidth=1)
+    axes[1].set_xlabel("Component")
+    axes[1].set_ylabel("Y loading")
+    axes[1].grid(True)
+
+    kegg_table = _safe_extract_kegg_table(kegg_mat)
+    if kegg_table is not None and not kegg_table.empty:
+        kegg_table = kegg_table.loc[
+            ~kegg_table["metClassLevel1"].isin(
+                ["Antibiotics", "Bufanolide derivatives [Fig]", "Vitamins and cofactors"]
+            )
+        ].copy()
+        spectra = np.vstack(kegg_table["abundance"].to_numpy())
+        spectra = spectra / np.linalg.norm(spectra, axis=1, keepdims=True)
+        _, predicted = learner.map_to_latent_space(spectra)
+        axes[0].scatter(predicted[:, 0], predicted[:, 1], alpha=0.35, s=10)
+
+    path = output_dir / "loadings.png"
+    figure.savefig(path, dpi=200)
+    plt.close(figure)
+    return path
+
+
+def run_workflow(
+    gcms_csv_dir: str | Path = "gcmsCSVs",
+    extracted_peaks_dir: str | Path = "extractedPeaks",
+    folds_dir: str | Path = "folds",
+    kegg_mat_path: str | Path = "kegg/keggCompoundsWithFiehlibSpectrum.mat",
+    *,
+    regenerate_peaks: bool = False,
+    kfold_learn: int = 0,
+    max_components: int = 30,
+    nrandomized: int = 1000,
+) -> WorkflowResult:
+    gcms_csv_dir = Path(gcms_csv_dir)
+    extracted_peaks_dir = Path(extracted_peaks_dir)
+    folds_dir = Path(folds_dir)
+    folds_dir.mkdir(parents=True, exist_ok=True)
+
+    peaks_path = extracted_peaks_dir / "tblPeaksIntegrated.csv"
+    spectra_path = extracted_peaks_dir / "tblSpectra.csv"
+    if regenerate_peaks or not peaks_path.exists() or not spectra_path.exists():
+        peaks_integrated, spectra = extract_spectra_and_integrate(gcms_csv_dir, extracted_peaks_dir)
+    else:
+        peaks_integrated = pd.read_csv(peaks_path)
+        spectra = pd.read_csv(spectra_path)
+
+    sample_columns = list(peaks_integrated.columns[1:])
+    cell_types = [_infer_cell_type(name) for name in sample_columns]
+    p_values = [
+        _ols_anova_p_value(peaks_integrated.loc[row_index, sample_columns].to_numpy(dtype=float), cell_types)
+        for row_index in range(len(peaks_integrated))
+    ]
+    filtered = peaks_integrated.loc[np.array(p_values) < 0.05, ["peakId", *[name for name in sample_columns if not name.startswith("M")]]].copy()
+
+    scaled = _prepare_scaled_table(filtered)
+    scaling_model = _fit_scaling_model(scaled)
+    scaled["areaModel"] = scaling_model.resid
+
+    fold_change_model = _fit_fold_change_model(scaled)
+    coefficients = _coefficient_frame(fold_change_model)
+    if coefficients.empty:
+        raise RuntimeError("The mixed-effects fold-change model did not produce any B/L coefficients.")
+
+    fold_changes = coefficients.pivot(index="peakID", columns="cell", values="Estimate").reset_index().rename_axis(columns=None)
+    pvals = coefficients.pivot(index="peakID", columns="cell", values="pValue").reset_index().rename_axis(columns=None)
+    lower = coefficients.pivot(index="peakID", columns="cell", values="Lower").reset_index().rename_axis(columns=None)
+    upper = coefficients.pivot(index="peakID", columns="cell", values="Upper").reset_index().rename_axis(columns=None)
+
+    fold_changes = fold_changes.merge(pvals, on="peakID", suffixes=("", "_p"))
+    fold_changes = fold_changes.merge(lower, on="peakID", suffixes=("", "_lower"))
+    fold_changes = fold_changes.merge(upper, on="peakID", suffixes=("", "_upper"))
+
+    log2_factor = np.log(2.0)
+    for column in ["B", "L", "B_lower", "L_lower", "B_upper", "L_upper"]:
+        if column in fold_changes:
+            fold_changes[column] = fold_changes[column] / log2_factor
+
+    fold_changes = fold_changes.rename(
+        columns={
+            "B_p": "pValB",
+            "L_p": "pValL",
+            "B_lower": "lowerB",
+            "L_lower": "lowerL",
+            "B_upper": "upperB",
+            "L_upper": "upperL",
+        }
+    )
+    fold_changes = fold_changes[["peakID", "B", "L", "pValB", "pValL", "lowerB", "lowerL", "upperB", "upperL"]]
+    fold_changes = fold_changes.sort_values("peakID").reset_index(drop=True)
+    fold_changes.to_csv(folds_dir / "peakFoldChanges.csv", index=False)
+
+    spectra = spectra.copy()
+    spectra["peakId"] = spectra["peakId"].astype(str)
+    fold_changes["peakID"] = fold_changes["peakID"].astype(str)
+    spectra = spectra.loc[spectra["peakId"].isin(fold_changes["peakID"]), :].sort_values("peakId").reset_index(drop=True)
+    fold_changes = fold_changes.sort_values("peakID").reset_index(drop=True)
+
+    matrix_spectra = spectra.iloc[:, 1:].to_numpy(dtype=float)
+    x = matrix_spectra / np.linalg.norm(matrix_spectra, axis=1, keepdims=True)
+    y = fold_changes[["B", "L"]].to_numpy(dtype=float)
+    learner = MetaboLiteLearner(x, y, kfold=kfold_learn, max_components=max_components, nrandomized=nrandomized)
+
+    _plot_variance_explained(learner, folds_dir)
+    _plot_loadings(learner, folds_dir, Path(kegg_mat_path))
+
+    return WorkflowResult(fold_changes=fold_changes, spectra=spectra, learner=learner)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "metabolite-learner"
+version = "0.1.0"
+description = "Python port of the MetaboLiteLearner MATLAB workflow for GC/MS metabolic rewiring analysis."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [
+  { name = "Joao Xavier" }
+]
+dependencies = [
+  "numpy>=1.26",
+  "pandas>=2.1",
+  "scipy>=1.11",
+  "scikit-learn>=1.4",
+  "statsmodels>=0.14",
+  "matplotlib>=3.8"
+]
+
+[project.scripts]
+metabolite-learner = "metabolite_learner.cli:main"
+
+[tool.setuptools]
+packages = ["metabolite_learner"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy>=1.26
+pandas>=2.1
+scipy>=1.11
+scikit-learn>=1.4
+statsmodels>=0.14
+matplotlib>=3.8

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+import unittest
+
+from metabolite_learner.cli import build_parser
+
+
+class CliParserTests(unittest.TestCase):
+    def test_run_workflow_command_parses(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["run-workflow"])
+        self.assertEqual(args.command, "run-workflow")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Enable running the MetaboLiteLearner pipeline without MATLAB by porting the core pipeline to Python and providing a command-line interface. 
- Preserve the original analysis steps (Agilent conversion, TIC peak extraction, mixed-effects fold-change estimation, PLS learning and plotting) while making the raw-data decoder injectable to accommodate proprietary Agilent `.D` directories. 
- Provide a maintainable, packaging-ready Python project layout so downstream users can install and run the workflow with standard Python scientific libraries. 

### Description
- Added a Python package `metabolite_learner` with modules: `agilent.py` (pluggable Agilent→CSV conversion expecting 2401×550 matrices), `extract.py` (TIC peak detection via `scipy.signal.find_peaks`, peak integration, and spectrum export), `pls.py` (PLS learner mirroring MATLAB logic using `scikit-learn` and CV-driven component selection), `workflow.py` (end-to-end pipeline using `statsmodels` for ANOVA/mixed-effects models and producing fold-change CSV + plots), and `cli.py` (CLI entrypoint with `convert-agilent`, `extract-peaks`, and `run-workflow`).
- Added packaging and metadata files (`pyproject.toml`, `requirements.txt`), updated `README.md` to document usage and parity notes, and added a `.gitignore` to ignore bytecode artifacts. 
- Added a lightweight unit test (`tests/test_cli.py`) that validates the CLI parser and included simple output paths for generated artifacts (`extractedPeaks/*.csv`, `folds/*.png`, `folds/peakFoldChanges.csv`).

### Testing
- Ran a syntax/bytecode check with `python3 -m compileall metabolite_learner tests` which completed successfully. 
- Executed the unit test suite with `python3 -m unittest discover -s tests -v`, and the CLI parser test passed (`OK`).
- Attempted to install the Python scientific stack to run the full data-driven workflow, but package installation was blocked by the environment network/proxy policy, so end-to-end numeric verification was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bebf389d5883268b84b5d5e1e03355)