### PR TITLE
Support Agilent .ms/TIC loaders, rebin MS data, fix PLS beta orientation, and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+folds/*.png

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This produces:
 python3 -m metabolite_learner convert-agilent rawAgilentData/... gcmsCSVs
 ```
 
-Unlike the MATLAB version, the Python implementation does not hard-code a dependency on `chromatography-master`. Instead, `convert_agilent_to_csv` accepts a pluggable loader because Agilent `.D` directories are proprietary vendor containers. Out of the box, the function looks for a pre-exported matrix CSV inside each `.D` directory.
+Unlike the MATLAB version, the Python implementation does not hard-code a dependency on `chromatography-master`. Instead, `convert_agilent_to_csv` accepts a pluggable loader because Agilent `.D` directories are proprietary vendor containers. Out of the box, the function now reads the raw `*.ms` file inside each `.D` directory, decodes the TIC/XIC data, bins the spectra onto the workflow's m/z grid, and interpolates onto the same retention-time grid as the MATLAB workflow. If raw MS data is unavailable, it falls back to pre-exported matrix or TIC files inside the sample directory.
 
 ## Notes on parity with MATLAB
 

--- a/metabolite_learner/agilent.py
+++ b/metabolite_learner/agilent.py
@@ -9,24 +9,123 @@ import pandas as pd
 TIME_GRID = np.round(np.arange(6.0, 30.0 + 0.01, 0.01), 2)
 MZ_GRID = np.arange(50, 600, 1)
 EXPECTED_SHAPE = (TIME_GRID.size, MZ_GRID.size)
+DEFAULT_PRECISION = 3
 
 Loader = Callable[[Path], np.ndarray]
 
 
+def _read_prefixed_string(handle, offset: int) -> str:
+    handle.seek(offset)
+    length = int(np.fromfile(handle, dtype=np.dtype("u1"), count=1)[0])
+    payload = np.fromfile(handle, dtype=np.dtype("u1"), count=length).tobytes()
+    return payload.decode("latin1", errors="ignore").strip("\x00 ").strip()
+
+
+def _read_big_endian_array(handle, offset: int, dtype: str, count: int, *, stride: int = 0) -> np.ndarray:
+    handle.seek(offset)
+    values_dtype = np.dtype(dtype)
+    if stride == 0:
+        return np.fromfile(handle, dtype=values_dtype, count=count)
+
+    values = np.empty(count, dtype=values_dtype)
+    for index in range(count):
+        values[index] = np.fromfile(handle, dtype=values_dtype, count=1)[0]
+        if stride:
+            handle.seek(stride, 1)
+    return values
+
+
+def _load_agilent_ms_file(ms_path: Path, precision: int = DEFAULT_PRECISION) -> np.ndarray:
+    with ms_path.open("rb") as handle:
+        version = _read_prefixed_string(handle, 0)
+        if version not in {"2", "20"}:
+            raise ValueError(f"Unsupported Agilent MS version {version!r} in {ms_path}.")
+
+        scans = int(_read_big_endian_array(handle, 278, ">u4", 1)[0])
+        tic_offset = int(_read_big_endian_array(handle, 260, ">i4", 1)[0]) * 2 - 2
+        xic_offsets = _read_big_endian_array(handle, tic_offset, ">i4", scans, stride=8).astype(np.int64) * 2 - 2
+
+        time = _read_big_endian_array(handle, tic_offset + 4, ">i4", scans, stride=8).astype(float) / 60000.0
+
+        mz_values: list[np.ndarray] = []
+        intensity_values: list[np.ndarray] = []
+        counts: list[int] = []
+
+        for offset in xic_offsets:
+            scan_size = int((_read_big_endian_array(handle, int(offset), ">i2", 1)[0] - 18) / 2 + 2)
+            counts.append(scan_size)
+            mz_values.append(_read_big_endian_array(handle, int(offset) + 18, ">u2", scan_size, stride=2))
+            intensity_values.append(_read_big_endian_array(handle, int(offset) + 20, ">u2", scan_size, stride=2))
+
+    mz = np.concatenate(mz_values).astype(np.float64) / 20.0
+    raw_intensity = np.concatenate(intensity_values).astype(np.uint16)
+    intensity = np.bitwise_and(raw_intensity, np.uint16(16383)).astype(np.float64) * (
+        8.0 ** np.abs(np.right_shift(raw_intensity, 14).astype(np.int16))
+    )
+
+    mz = np.round(mz * 10**precision) / 10**precision
+    unique_mz = np.unique(mz)
+
+    index_end = np.cumsum(counts)
+    index_start = np.concatenate(([0], index_end[:-1]))
+    xic = np.zeros((time.size, unique_mz.size), dtype=float)
+    columns = np.searchsorted(unique_mz, mz)
+    for scan_index, (start, end) in enumerate(zip(index_start, index_end)):
+        xic[scan_index, columns[start:end]] = intensity[start:end]
+
+    rebinned = np.zeros((time.size, MZ_GRID.size), dtype=float)
+    for mz_index in range(MZ_GRID.size - 1):
+        mask = (unique_mz >= MZ_GRID[mz_index]) & (unique_mz < MZ_GRID[mz_index + 1])
+        if np.any(mask):
+            rebinned[:, mz_index] = xic[:, mask].sum(axis=1)
+
+    last_mask = unique_mz >= MZ_GRID[-1]
+    if np.any(last_mask):
+        rebinned[:, -1] = xic[:, last_mask].sum(axis=1)
+
+    matrix = np.empty(EXPECTED_SHAPE, dtype=float)
+    for mz_index in range(rebinned.shape[1]):
+        matrix[:, mz_index] = np.interp(TIME_GRID, time, rebinned[:, mz_index], left=np.nan, right=np.nan)
+    return matrix
+
+
+def _load_tic_front_file(tic_path: Path) -> np.ndarray:
+    separator = "\t" if tic_path.suffix.lower() == ".tsv" else ","
+    tic = pd.read_csv(tic_path, sep=separator, skiprows=2, header=None, usecols=[0, 1]).to_numpy(dtype=float)
+    if tic.ndim != 2 or tic.shape[1] != 2:
+        raise ValueError(f"Expected retention-time/intensity pairs in {tic_path}.")
+
+    order = np.argsort(tic[:, 0], kind="stable")
+    retention_time = tic[order, 0]
+    intensity = tic[order, 1]
+    resampled = np.interp(TIME_GRID, retention_time, intensity, left=0.0, right=0.0)
+
+    matrix = np.zeros(EXPECTED_SHAPE, dtype=float)
+    matrix[:, 0] = resampled
+    return matrix
+
+
 def _identity_matrix_loader(sample_path: Path) -> np.ndarray:
+    ms_candidates = sorted(path for path in sample_path.iterdir() if path.suffix.lower() == ".ms")
+    if ms_candidates:
+        return _load_agilent_ms_file(ms_candidates[0])
+
     candidates = [
         sample_path / "matrix.csv",
         sample_path / "xic.csv",
         sample_path / f"{sample_path.stem}.csv",
+        sample_path / "tic_front.csv",
+        sample_path / "tic_front.tsv",
     ]
     for candidate in candidates:
         if candidate.exists():
-            data = pd.read_csv(candidate, header=None).to_numpy(dtype=float)
-            return data
+            if candidate.name.startswith("tic_front."):
+                return _load_tic_front_file(candidate)
+            return pd.read_csv(candidate, header=None).to_numpy(dtype=float)
+
     raise FileNotFoundError(
-        "No matrix CSV was found inside the Agilent sample directory. "
-        "The Python port expects a pluggable loader that can decode the proprietary "
-        ".D directory into the 2401x550 GC/MS matrix used elsewhere in the repo."
+        "No supported Agilent raw-data, matrix, or TIC file was found inside the sample directory. "
+        "The default loader looks for *.ms, matrix.csv, xic.csv, <sample>.csv, tic_front.csv, or tic_front.tsv."
     )
 
 
@@ -51,8 +150,8 @@ def convert_agilent_to_csv(
         Destination for the generated CSV matrix files.
     loader:
         Callable that receives a sample directory and returns a 2401x550 matrix.
-        When omitted, the function looks for a pre-exported matrix CSV inside each
-        sample directory.
+        When omitted, the function looks for raw `*.ms` files first and then falls
+        back to matrix/TIC exports inside each sample directory.
     sample_dirs:
         Optional explicit iterable of sample directories to process.
     """

--- a/metabolite_learner/pls.py
+++ b/metabolite_learner/pls.py
@@ -74,7 +74,10 @@ class MetaboLiteLearner:
         loss = (y_pred - y) ** 2
         sse = float(loss.sum())
 
-        beta = np.vstack([model.intercept_.reshape(1, -1), model.coef_])
+        coefficients = np.asarray(model.coef_, dtype=float)
+        if coefficients.shape == (y.shape[1], x.shape[1]):
+            coefficients = coefficients.T
+        beta = np.vstack([np.asarray(model.intercept_, dtype=float).reshape(1, -1), coefficients])
         pctvar = self._calculate_pctvar(x, y, model)
         return (
             model,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,13 @@
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
+import numpy as np
+import pandas as pd
+
+from metabolite_learner.agilent import EXPECTED_SHAPE, TIME_GRID, convert_agilent_to_csv
 from metabolite_learner.cli import build_parser
+from metabolite_learner.pls import MetaboLiteLearner
 
 
 class CliParserTests(unittest.TestCase):
@@ -8,6 +15,65 @@ class CliParserTests(unittest.TestCase):
         parser = build_parser()
         args = parser.parse_args(["run-workflow"])
         self.assertEqual(args.command, "run-workflow")
+
+
+class PlsRegressionCompatibilityTests(unittest.TestCase):
+    def test_learn_builds_beta_with_feature_rows_and_target_columns(self) -> None:
+        rng = np.random.default_rng(0)
+        x = rng.normal(size=(12, 6))
+        y = rng.normal(size=(12, 2))
+
+        learner = MetaboLiteLearner(x, y, kfold=3, max_components=2, nrandomized=2)
+
+        self.assertEqual(learner.beta.shape, (x.shape[1] + 1, y.shape[1]))
+
+
+class AgilentConversionTests(unittest.TestCase):
+    def test_convert_agilent_to_csv_reads_tic_front_from_d_directory(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            sample_dir = root / "ExampleSample.D"
+            sample_dir.mkdir()
+
+            tic_front = sample_dir / "tic_front.csv"
+            tic_front.write_text(
+                "\n".join(
+                    [
+                        "ExampleSample.D",
+                        "Start of data points",
+                        "6.00,10",
+                        "18.00,20",
+                        "30.00,30",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            output_dir = root / "out"
+            written = convert_agilent_to_csv(root, output_dir)
+
+            self.assertEqual(written, [output_dir / "ExampleSample.csv"])
+            converted = pd.read_csv(written[0], header=None).to_numpy(dtype=float)
+
+            self.assertEqual(converted.shape, EXPECTED_SHAPE)
+            np.testing.assert_allclose(converted[:, 0], np.interp(TIME_GRID, [6.0, 18.0, 30.0], [10.0, 20.0, 30.0]))
+            np.testing.assert_allclose(converted[:, 1:], 0.0)
+
+    def test_convert_agilent_to_csv_matches_reference_csv_for_real_d_directory(self) -> None:
+        sample_dir = Path(
+            "rawAgilentData/metastasis_lineages_3replicates_3runs_10302020/P_plate3_run1_10302020.D"
+        )
+        reference_csv = Path("gcmsCSVs/P_plate3_run1_10302020.csv")
+
+        with TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            written = convert_agilent_to_csv(sample_dir.parent, output_dir, sample_dirs=[sample_dir])
+            converted = pd.read_csv(written[0], header=None).to_numpy(dtype=float)
+            reference = pd.read_csv(reference_csv, header=None).to_numpy(dtype=float)
+
+        self.assertEqual(converted.shape, EXPECTED_SHAPE)
+        np.testing.assert_allclose(converted, reference, rtol=1e-10, atol=1e-6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Enable the Python workflow to decode Agilent proprietary raw `*.ms` files and handle TIC exports so sample `.D` directories can be converted without external MATLAB tooling. 
- Ensure the PLS beta matrix has a consistent shape of `(n_features + 1, n_targets)` regardless of `scikit-learn` `coef_` layout. 
- Add tests and ignore rules to cover the new loader behavior and PLS compatibility.

### Description
- Implemented raw Agilent `*.ms` decoding in `metabolite_learner/agilent.py` with functions `_read_prefixed_string`, `_read_big_endian_array`, and `_load_agilent_ms_file` that parse, bin onto `MZ_GRID`, and interpolate onto `TIME_GRID` to produce the expected matrix shape `EXPECTED_SHAPE`.
- Added a TIC front loader `_load_tic_front_file` and updated the default `_identity_matrix_loader` to prefer `*.ms` files and fall back to `matrix.csv`, `xic.csv`, `<sample>.csv`, `tic_front.csv`, or `tic_front.tsv`, with improved error messaging.
- Updated `convert_agilent_to_csv` documentation to reflect the new default loader behavior.
- Fixed PLS coefficient orientation in `metabolite_learner/pls.py` by normalizing `model.coef_` shape and building `beta` from a correctly shaped coefficients matrix and `model.intercept_`.
- Added tests in `tests/test_cli.py` that assert the CLI parser, the PLS `beta` shape via `PlsRegressionCompatibilityTests`, and Agilent conversion behavior including reading `tic_front.csv` and validating conversion against a reference CSV; and added `folds/*.png` to `.gitignore`.

### Testing
- Ran the unit test suite (`pytest -q`), including `CliParserTests`, `PlsRegressionCompatibilityTests`, and `AgilentConversionTests`, and all tests passed.
- The new `AgilentConversionTests::test_convert_agilent_to_csv_reads_tic_front_from_d_directory` verifies interpolation onto `TIME_GRID` and succeeded.
- The `AgilentConversionTests::test_convert_agilent_to_csv_matches_reference_csv_for_real_d_directory` compares a converted real `.D` directory to the reference CSV and succeeded within numeric tolerances.
- The PLS compatibility test confirms `beta.shape == (n_features + 1, n_targets)` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef9da1850832687f1b7f764fa013d)